### PR TITLE
add fakeit-client for gRPC chat-API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,15 @@ check-coverage: install-go-test-coverage
 	go test ./... -coverprofile=./coverage.out  -covermode=atomic -coverpkg=./...
 	$(LOCAL_BIN)/go-test-coverage --config=./.testcoverage.yml
 
-build: build-server
+build: build-server build-client
 
 build-server: generate
 	mkdir -p $(BUILD_DIR)
 	go build -o $(BUILD_DIR)/server cmd/grpc-server/main.go
 
+build-client: generate
+	mkdir -p $(BUILD_DIR)
+	go build -o $(BUILD_DIR)/client cmd/grpc-client/main.go
 
 run-server: build-server
 	$(BUILD_DIR)/server

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install-deps generate generate-chat-api install-golangci-lint lint lint-feature clean test build build-server run-server
+.PHONY: all install-deps generate generate-chat-api install-golangci-lint lint lint-feature clean test build build-server build-client run-server
 all: clean generate build lint check-coverage  
 
 

--- a/cmd/grpc-client/main.go
+++ b/cmd/grpc-client/main.go
@@ -1,0 +1,70 @@
+// Package main provides the entry point for the chat client.
+package main
+
+import (
+	"context"
+	"log"
+	"math"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v7"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	srv "github.com/based-chat/chat-server/pkg/chat/v1"
+)
+
+const (
+	grpcPort       = ":50051"
+	host           = "0.0.0.0"
+	maxTimemeout   = 3 * time.Second
+	fakeCountUsers = 5
+)
+
+func main() {
+	conn, err := grpc.NewClient(host+grpcPort, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Default().Println("failed to connect: " + err.Error())
+	}
+	defer func() { _ = conn.Close() }() // nolintconn.Close()
+
+	c := srv.NewChatV1Client(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), maxTimemeout)
+	defer cancel()
+
+	usernames := make([]string, fakeCountUsers)
+	for i := range usernames {
+		usernames[i] = gofakeit.Username()
+	}
+
+	_, err = c.Create(ctx, &srv.CreateRequest{Usernames: usernames})
+	if err != nil {
+		log.Default().Println("failed to create: " + err.Error())
+	}
+
+	_, err = c.SendMessage(ctx, &srv.SendMessageRequest{
+		ChatId:  abs(gofakeit.Int64()),
+		Sender:  gofakeit.Username(),
+		Message: gofakeit.Phrase(),
+	})
+	if err != nil {
+		log.Default().Println("failed to send message: " + err.Error())
+	}
+
+	_, err = c.Delete(ctx, &srv.DeleteRequest{
+		Id: abs(gofakeit.Int64()),
+	})
+	if err != nil {
+		log.Default().Println("failed to delete: " + err.Error())
+	}
+}
+
+func abs(x int64) int64 {
+	if x == math.MinInt64 {
+		return math.MaxInt64
+	}
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/cmd/grpc-client/main.go
+++ b/cmd/grpc-client/main.go
@@ -4,12 +4,13 @@ package main
 import (
 	"context"
 	"log"
-	"math"
 	"time"
 
 	"github.com/brianvoe/gofakeit/v7"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/based-chat/chat-server/utilites"
 
 	srv "github.com/based-chat/chat-server/pkg/chat/v1"
 )
@@ -17,19 +18,27 @@ import (
 const (
 	grpcPort       = ":50051"
 	host           = "0.0.0.0"
-	maxTimemeout   = 3 * time.Second
+	maxTimeout     = 3 * time.Second
 	fakeCountUsers = 5
 )
 
+// main demonstrates basic usage of the chat service rpc api.
+// It connects to the server, creates a chat with a few users,
+// sends a message, and then deletes the chat.
 func main() {
 	conn, err := grpc.NewClient(host+grpcPort, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		log.Default().Println("failed to connect: " + err.Error())
+		log.Fatalf("failed to connect: %v", err)
 	}
-	defer func() { _ = conn.Close() }() // nolintconn.Close()
+	defer func() {
+		connErr := conn.Close()
+		if connErr != nil {
+			log.Default().Println("failed to close connection: " + connErr.Error())
+		}
+	}()
 
 	c := srv.NewChatV1Client(conn)
-	ctx, cancel := context.WithTimeout(context.Background(), maxTimemeout)
+	ctx, cancel := context.WithTimeout(context.Background(), maxTimeout)
 	defer cancel()
 
 	usernames := make([]string, fakeCountUsers)
@@ -37,34 +46,27 @@ func main() {
 		usernames[i] = gofakeit.Username()
 	}
 
-	_, err = c.Create(ctx, &srv.CreateRequest{Usernames: usernames})
+	createResponse, err := c.Create(ctx, &srv.CreateRequest{Usernames: usernames})
 	if err != nil {
 		log.Default().Println("failed to create: " + err.Error())
+		return
 	}
 
 	_, err = c.SendMessage(ctx, &srv.SendMessageRequest{
-		ChatId:  abs(gofakeit.Int64()),
+		ChatId:  createResponse.GetId(),
 		Sender:  gofakeit.Username(),
 		Message: gofakeit.Phrase(),
 	})
 	if err != nil {
 		log.Default().Println("failed to send message: " + err.Error())
+		return
 	}
 
 	_, err = c.Delete(ctx, &srv.DeleteRequest{
-		Id: abs(gofakeit.Int64()),
+		Id: utilites.Abs(createResponse.GetId()),
 	})
 	if err != nil {
 		log.Default().Println("failed to delete: " + err.Error())
+		return
 	}
-}
-
-func abs(x int64) int64 {
-	if x == math.MinInt64 {
-		return math.MaxInt64
-	}
-	if x < 0 {
-		return -x
-	}
-	return x
 }

--- a/cmd/grpc-server/main.go
+++ b/cmd/grpc-server/main.go
@@ -4,7 +4,6 @@ package main
 import (
 	"context"
 	"log"
-	"math"
 	"net"
 	"time"
 
@@ -12,6 +11,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/based-chat/chat-server/utilites"
 
 	srv "github.com/based-chat/chat-server/pkg/chat/v1"
 )
@@ -25,22 +26,27 @@ type server struct {
 	srv.UnimplementedChatV1Server
 }
 
+// Create returns a fake chat id.
 func (s *server) Create(_ context.Context, _ *srv.CreateRequest) (*srv.CreateResponse, error) {
 	return &srv.CreateResponse{
-		Id: abs(gofakeit.Int64()),
+		Id: utilites.Abs(gofakeit.Int64()),
 	}, nil
 }
 
+// Delete does nothing and returns no error.
 func (s *server) Delete(_ context.Context, _ *srv.DeleteRequest) (*emptypb.Empty, error) {
 	return &emptypb.Empty{}, nil
 }
 
+// SendMessage returns a fake message id.
 func (s *server) SendMessage(_ context.Context, _ *srv.SendMessageRequest) (*srv.SendMessageResponse, error) {
 	return &srv.SendMessageResponse{
-		Id: abs(gofakeit.Int64()),
+		Id: utilites.Abs(gofakeit.Int64()),
 	}, nil
 }
 
+// main starts a grpc server that listens on port 50051 and implements the
+// server-side rpc methods of the chat service.
 func main() {
 	addr, err := net.ResolveTCPAddr("tcp", host+grpcPort)
 	if err != nil {
@@ -64,14 +70,4 @@ func main() {
 	if err = s.Serve(listen); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}
-}
-
-func abs(x int64) int64 {
-	if x == math.MinInt64 {
-		return math.MaxInt64
-	}
-	if x < 0 {
-		return -x
-	}
-	return x
 }

--- a/utilites/util.go
+++ b/utilites/util.go
@@ -1,0 +1,17 @@
+// Package utilites provides utility functions.
+package utilites
+
+import "math"
+
+// Abs returns the absolute value of x. If x is the smallest negative number,
+// then the absolute value cannot be represented in int64, so the function
+// returns the largest positive number instead.
+func Abs(x int64) int64 {
+	if x == math.MinInt64 {
+		return math.MaxInt64
+	}
+	if x < 0 {
+		return -x
+	}
+	return x
+}


### PR DESCRIPTION
**Новые возможности**

Добавлен минимальный gRPC‑клиент для чата: 

1. подключается к серверу, 
2. выполняет краткую последовательность операций (создание пользователей, отправка сообщения, удаление), 
3. доступен как отдельный исполняемый файл клиента.

**Обслуживание**

Обновлён процесс сборки: 

1. команда сборки теперь формирует как сервер, так и клиент, обеспечивая единый поток сборки и готовые бинарные артефакты для обоих компонентов.